### PR TITLE
VRC 720 configuration: understanding and managing Heating Circuit (HC) basic parameters

### DIFF
--- a/ebusd-2.1.x/en/vaillant/15.700.csv
+++ b/ebusd-2.1.x/en/vaillant/15.700.csv
@@ -146,6 +146,7 @@ r,,Hc3MixerMovement,MixerMovement heating circuit 3,,,,1A00,,,EXP,,,"status of m
 r,,Hc3HeatCurveAdaption,HeatCurveAdaption heating circuit 3,,,,1C00,,,EXP,,,adaption applied to heating curve of Hc3
 r;w,,Hc3Status,Status heating circuit 3,,,,1B00,,,UCH,,,status of zone 2
 r;w,,Hc3PumpStatus,PumpStatus heating circuit 3,,,,1E00,,,UIN,,,pump status of zone 3
+# ##### heating circuit 4 #####,,,,,,,,,,,,,
 # ##### zone 1 #####,,,,,,,,,,,,,
 *r,,,,,,B524,02000300,,,IGN:4,,,
 *w,,,,,,B524,02010300,,,,,,


### PR DESCRIPTION
### Goal of the PR
 **To check and confirm basic set of registers in the ebusd configuration associated with the Heating Circuit (HC)**

**EBUSD regulator config (15.CTLV2.csv) implementation: [see JonesPD repository](https://github.com/jonesPD/ebusd-configuration/blob/master/ebusd-2.1.x/en/vaillant/15.ctlv2.csv)**

![pic1](https://github.com/stadid/ebusd-configuration/assets/122470717/5c0d2200-9868-4961-8d6a-06ed61444a47)

The only register to be found is External heat demand contact status at external module.
(**Hc*ExtHeatDemand** (RO) - should be 0/1)
